### PR TITLE
SoleXplorer compatibility

### DIFF
--- a/src/interfaces/MLJ.jl
+++ b/src/interfaces/MLJ.jl
@@ -100,6 +100,10 @@ function MMI.fit(m::SymbolicModel, verbosity::Integer, X, y, var_grouping, class
         # syntaxstring_kwargs = (; hidemodality = (length(var_grouping) == 1), variable_names_map = var_grouping)
     ))
 
+    translate_model = (m, preds)->ModalDecisionTrees.translate(m,
+        (; supporting_predictions=preds)
+    )
+
     rawmodel_full = model
     rawmodel = MDT.prune(model; simplify = true)
 
@@ -124,7 +128,7 @@ function MMI.fit(m::SymbolicModel, verbosity::Integer, X, y, var_grouping, class
             if simplify
                 sprinkledmodel = MDT.prune(sprinkledmodel; simplify = true)
             end
-            preds, translate_function(sprinkledmodel)
+            preds, translate_model(sprinkledmodel, preds)
         end,
         # TODO remove redundancy?
         model                       = solemodel,

--- a/src/interfaces/Sole/main.jl
+++ b/src/interfaces/Sole/main.jl
@@ -60,7 +60,8 @@ function translate(
 )
     pure_root = translate(ModalDecisionTrees.root(tree), ModalDecisionTrees.initconditions(tree); kwargs...)
 
-    info = merge(info, SoleModels.info(pure_root))
+    # info = merge(info, SoleModels.info(pure_root))
+    info = merge(SoleModels.info(pure_root), info)
     info = merge(info, (;))
 
     return SoleModels.DecisionTree(pure_root, info)


### PR DESCRIPTION
when performing a sprinkle to the model, to obtain a Sole compatible model, and prediction, the function sprinkle creates a Sole model but actual predictions aren't written in Sole struct (under the struct 'info') instead are passed as a second parameter.
SoleXplorer expets to find predictions inside the model, under info struct.

in order to have sprinkle properly working for SoleXplorer, i've added a function in mlj fit interface: 'translate_model', called by sprinkle in place of 'translate_function' that I kept as it is for safety.
the difference between translate_model and translate_function is that the first one accepts also predictions as a vector of string.
then, call translate function to convert the tree.
I also make a little change in translate function: since it return a wrong supporting predictions, if a vector of predictions is passed, it will be merged.